### PR TITLE
Do not open folder while running tests

### DIFF
--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -11,9 +11,11 @@ async function main() {
 		// The path to test runner
 		// Passed to --extensionTestsPath
 		const extensionTestsPath = path.resolve(__dirname, './suite/index');
+		const projectRoot = path.join(__dirname, '..', '..', '..');
+		const simpleProgramPath = path.join(projectRoot, 'src', 'test', 'simpleProgram');
 
 		// Download VS Code, unzip it and run the integration test
-		await runTests({ extensionDevelopmentPath, extensionTestsPath });
+		await runTests({ extensionDevelopmentPath, extensionTestsPath, launchArgs: [simpleProgramPath] });
 	} catch (err) {
 		console.error('Failed to run tests');
 		process.exit(1);

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -10,7 +10,6 @@ const simpleProgramPath = path.join(projectRoot, 'src', 'test', 'simpleProgram')
 
 suite('completion', () => {
 	setup(async () => {
-		await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(simpleProgramPath));
 		cp.execSync('bundle install; rbs collection install', { cwd: simpleProgramPath });
 	});
 
@@ -32,7 +31,6 @@ suite('completion', () => {
 
 suite('diagnostics', () => {
 	setup(async () => {
-		await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(simpleProgramPath));
 		cp.execSync('bundle install; rbs collection install', { cwd: simpleProgramPath });
 	});
 
@@ -71,7 +69,6 @@ suite('diagnostics', () => {
 
 suite('go to definitions', () => {
 	setup(async () => {
-		await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(simpleProgramPath));
 		cp.execSync('bundle install; rbs collection install', { cwd: simpleProgramPath });
 	});
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -12,7 +12,6 @@ suite('completion', () => {
 	setup(async () => {
 		await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(simpleProgramPath));
 		cp.execSync('bundle install; rbs collection install', { cwd: simpleProgramPath });
-		await waitLockFiles();
 	});
 
 	teardown(() => {
@@ -35,7 +34,6 @@ suite('diagnostics', () => {
 	setup(async () => {
 		await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(simpleProgramPath));
 		cp.execSync('bundle install; rbs collection install', { cwd: simpleProgramPath });
-		await waitLockFiles();
 	});
 
 	teardown(() => {
@@ -75,7 +73,6 @@ suite('go to definitions', () => {
 	setup(async () => {
 		await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.file(simpleProgramPath));
 		cp.execSync('bundle install; rbs collection install', { cwd: simpleProgramPath });
-		await waitLockFiles();
 	});
 
 	teardown(() => {
@@ -103,19 +100,6 @@ async function openTargetFile(path: string) {
 	await vscode.window.showTextDocument(doc);
 	await new Promise(res => setTimeout(res, 5000));
 	return doc;
-}
-
-async function waitLockFiles() {
-	await waitFile(path.join(simpleProgramPath, 'rbs_collection.lock.yaml'));
-	await waitFile(path.join(simpleProgramPath, 'Gemfile.lock'));
-	await waitFile(path.join(simpleProgramPath, '.gem_rbs_collection'));
-}
-
-async function waitFile(file: string) {
-	while (true) {
-		if (fs.existsSync(file)) break;
-		await new Promise(res => setTimeout(res, 500));
-	}
 }
 
 function cleanUpFiles() {


### PR DESCRIPTION
Currently, there is a random failure such as https://github.com/ruby/vscode-typeprof/actions/runs/3937131796/jobs/6734303933#step:7:92. The reason of this is a conflict between restarted and pre-restart tests. By opening folders, current running instance will be restarted. See https://github.com/microsoft/vscode/issues/58#issuecomment-205370778. To prevent the problem, we should not open folder while running tests.

Also, this PR cherry-picks the commit in https://github.com/ruby/vscode-typeprof/pull/5.