### PR TITLE
Await the start() call instead of onReady()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.20.2",
             "license": "MIT",
             "dependencies": {
-                "vscode-languageclient": "^7.0.0"
+                "vscode-languageclient": "^8.0.2"
             },
             "devDependencies": {
                 "@types/glob": "^8.0.0",
@@ -2472,24 +2472,24 @@
             "dev": true
         },
         "node_modules/vscode-jsonrpc": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-            "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
+            "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
             "engines": {
-                "node": ">=8.0.0 || >=10.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/vscode-languageclient": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
-            "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
+            "integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
             "dependencies": {
                 "minimatch": "^3.0.4",
-                "semver": "^7.3.4",
-                "vscode-languageserver-protocol": "3.16.0"
+                "semver": "^7.3.5",
+                "vscode-languageserver-protocol": "3.17.2"
             },
             "engines": {
-                "vscode": "^1.52.0"
+                "vscode": "^1.67.0"
             }
         },
         "node_modules/vscode-languageclient/node_modules/brace-expansion": {
@@ -2527,18 +2527,18 @@
             }
         },
         "node_modules/vscode-languageserver-protocol": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-            "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
+            "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
             "dependencies": {
-                "vscode-jsonrpc": "6.0.0",
-                "vscode-languageserver-types": "3.16.0"
+                "vscode-jsonrpc": "8.0.2",
+                "vscode-languageserver-types": "3.17.2"
             }
         },
         "node_modules/vscode-languageserver-types": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+            "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
         },
         "node_modules/which": {
             "version": "2.0.2",
@@ -4451,18 +4451,18 @@
             "dev": true
         },
         "vscode-jsonrpc": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-            "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg=="
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
+            "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ=="
         },
         "vscode-languageclient": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
-            "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
+            "integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
             "requires": {
                 "minimatch": "^3.0.4",
-                "semver": "^7.3.4",
-                "vscode-languageserver-protocol": "3.16.0"
+                "semver": "^7.3.5",
+                "vscode-languageserver-protocol": "3.17.2"
             },
             "dependencies": {
                 "brace-expansion": {
@@ -4493,18 +4493,18 @@
             }
         },
         "vscode-languageserver-protocol": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-            "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
+            "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
             "requires": {
-                "vscode-jsonrpc": "6.0.0",
-                "vscode-languageserver-types": "3.16.0"
+                "vscode-jsonrpc": "8.0.2",
+                "vscode-languageserver-types": "3.17.2"
             }
         },
         "vscode-languageserver-types": {
-            "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-            "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+            "version": "3.17.2",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
+            "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
         },
         "which": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,6 @@
         "typescript": "^4.2.3"
     },
     "dependencies": {
-        "vscode-languageclient": "^7.0.0"
+        "vscode-languageclient": "^8.0.2"
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -257,7 +257,7 @@ function startTypeProf(folder: vscode.WorkspaceFolder) {
   showStatus("Try to start TypeProf for IDE");
 
   progressBarItem.show();
-  const typeprof = getTypeProfVersion(folder, (err, version) => {
+  const typeprof = getTypeProfVersion(folder, async (err, version) => {
     if (err !== null) {
       showStatus(`Ruby TypeProf is not configured`);
       showFailedStatus();
@@ -266,18 +266,9 @@ function startTypeProf(folder: vscode.WorkspaceFolder) {
     }
     showStatus(`Starting Ruby TypeProf (${version})...`);
     const client = invokeTypeProf(folder);
-    client.onReady()
-      .then(() => {
-        showStatus("Ruby TypeProf is running");
-      })
-      .catch((e: any) => {
-        showStatus(`Failed to start Ruby TypeProf: ${e}`);
-        showFailedStatus();
-        return;
-      });
     progressBarItem.hide();
     statusBarItem.show();
-    client.start();
+    await client.start();
     clientSessions.set(folder, { kind: "running", workspaceFolder: folder, client });
   });
 


### PR DESCRIPTION
> As a consequence the onReady() got removed since extensions can await the start() call now.

FYI: [https://github.com/Microsoft/vscode-languageserver-node\#3170-protocol-800-json-rpc-800-client-and-800-server](https://github.com/Microsoft/vscode-languageserver-node/#3170-protocol-800-json-rpc-800-client-and-800-server)