### PR TITLE
Remove async keyword to prevent timeout error in tests

### DIFF
--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -9,7 +9,7 @@ const projectRoot = path.join(__dirname, '..', '..', '..', '..');
 const simpleProgramPath = path.join(projectRoot, 'src', 'test', 'simpleProgram');
 
 suite('completion', () => {
-  setup(async () => {
+  setup(() => {
     cp.execSync('bundle install; rbs collection install', { cwd: simpleProgramPath });
   });
 
@@ -30,7 +30,7 @@ suite('completion', () => {
 });
 
 suite('diagnostics', () => {
-  setup(async () => {
+  setup(() => {
     cp.execSync('bundle install; rbs collection install', { cwd: simpleProgramPath });
   });
 
@@ -68,7 +68,7 @@ suite('diagnostics', () => {
 });
 
 suite('go to definitions', () => {
-  setup(async () => {
+  setup(() => {
     cp.execSync('bundle install; rbs collection install', { cwd: simpleProgramPath });
   });
 


### PR DESCRIPTION
Sometimes, random failure such as https://github.com/ruby/vscode-typeprof/actions/runs/4100763458/jobs/7071885391/#step:7:93 has occurred in setup function. To avoid it, This PR stops async processing in setup function.