### PR TITLE
Do not analyze Gemfile

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -228,7 +228,7 @@ function invokeTypeProf(folder: vscode.WorkspaceFolder): LanguageClient {
 
     const clientOptions: LanguageClientOptions = {
         documentSelector: [
-            { scheme: 'file', language: 'ruby' },
+            { scheme: 'file', language: 'ruby', pattern: '**/*.rb' },
             { scheme: 'file', language: 'rbs' },
         ],
         outputChannel,


### PR DESCRIPTION
Currently, Gemfile is the subject of the analysis, but it does not provide users useful information.