### PR TITLE
Run CI for macOS

### DIFF
--- a/.github/workflows/vscode.yml
+++ b/.github/workflows/vscode.yml
@@ -16,8 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: support other platform such as macos
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         ruby: ['3.1.0']
     runs-on: ${{ matrix.os }}
     steps:
@@ -43,6 +42,16 @@ jobs:
     - name: Test with Xvfb
       run: xvfb-run -a npm test
       if: ${{ runner.os == 'Linux' }}
+    # HACK: Workaround to prevent $PATH from being modified unexpectedly on macOS. See below:
+    # - https://code.visualstudio.com/docs/terminal/profiles#_why-are-there-duplicate-paths-in-the-terminals-path-environment-variable-andor-why-are-they-reversed-on-macos
+    # - https://github.com/microsoft/vscode/issues/94153
+    - name: Update '.*rc' scripts for macOS
+      run: |
+        echo "export PATH=${RUBY_BIN_PATH}:\${PATH}" >> ~/.bashrc
+        echo "export PATH=${RUBY_BIN_PATH}:\${PATH}" >> ~/.zshrc
+      if: ${{ runner.os == 'macOS' }}
+      env:
+        RUBY_BIN_PATH: ${{ format('{0}/{1}', steps.setup-ruby.outputs.ruby-prefix, 'bin') }}
     - name: Test
       run: npm test
       if: ${{ runner.os != 'Linux' }}


### PR DESCRIPTION
A workaround is necessary to prevent a `$PATH` problem. See below:

https://code.visualstudio.com/docs/terminal/profiles#_why-are-there-duplicate-paths-in-the-terminals-path-environment-variable-andor-why-are-they-reversed-on-macos

Closes #103

Note: #113 should fix flaky tests on Windows.