### PR TITLE
Automate creating tag in releasing process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,12 +1,29 @@
 name: Release
 on:
   push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+    branches:
+    - master
 
-# The following codes are borrowed from https://github.com/ruby/vscode-rdbg/blob/master/.github/workflows/release.yml.
 jobs:
+  tagpr:
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.run-tagpr.outputs.tag }}
+    steps:
+    - uses: actions/checkout@96f53100ba2a5449eb71d2e6604bbcd94b9449b5 # v3.5.3
+    - id: run-tagpr
+      uses: Songmu/tagpr@43d52e123cf8d55db9d602601f115f530588e2f8 # v1.1.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # The following codes are borrowed from https://github.com/ruby/vscode-rdbg/blob/master/.github/workflows/release.yml.
   publish:
+    needs: tagpr
+    if: needs.tagpr.outputs.tag != ''
     runs-on: ubuntu-latest
     steps:
     - name: Checkout


### PR DESCRIPTION
We currently create tags manually when releasing new changes. To streamline this process, we can automate it using https://github.com/Songmu/tagpr. When merging a pull request, tag generates a corresponding PR, as seen in this example: https://github.com/ono-max/vscode-launchable/pull/2.