### PR TITLE
Update regex to get the version

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -152,7 +152,7 @@ function getTypeProfVersion(
         if (code === 0) {
             const str = output.trim();
             log(`typeprof version: ${str}`);
-            const version = /^typeprof (\d+.\d+.\d+)$/.exec(str);
+            const version = /typeprof (\d+.\d+.\d+)$/m.exec(str);
             if (version && version.length === 2) {
                 if (compareVersions(version[1], '0.20.0') >= 0) {
                     callback(null, version[1]);


### PR DESCRIPTION
If there is any output while loading `.zshrc`, TypeProf will not start because it cannot get the version.
In my use case, I was loading [.iterm2_shell_integration.zsh](https://github.com/gnachman/iTerm2/blob/v3.5.13/Resources/shell_integration/iterm2_shell_integration.zsh) in the `.zshrc`.

To avoid this problem, remove the `^` from the regular expression.
I think it is enough to check the end of the output with `$`.

<img width="951" alt="スクリーンショット 2025-05-01 22 15 43" src="https://github.com/user-attachments/assets/cd209292-79d3-48c3-ae99-8622b7955ff7" />
