### PR TITLE
Remove unnecessary `/m` flag

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -152,7 +152,7 @@ function getTypeProfVersion(
         if (code === 0) {
             const str = output.trim();
             log(`typeprof version: ${str}`);
-            const version = /typeprof (\d+.\d+.\d+)$/m.exec(str);
+            const version = /typeprof (\d+.\d+.\d+)$/.exec(str);
             if (version && version.length === 2) {
                 if (compareVersions(version[1], '0.20.0') >= 0) {
                     callback(null, version[1]);


### PR DESCRIPTION
The version is always output at the end of the output, so there is no need to use `/m` flag.

refs: https://github.com/ruby/vscode-typeprof/pull/293#discussion_r2070342419